### PR TITLE
root account can have password blank if password used

### DIFF
--- a/debian/additions/debian-start.inc.sh
+++ b/debian/additions/debian-start.inc.sh
@@ -65,8 +65,8 @@ function check_root_accounts() {
   
   logger -p daemon.info -i -t$0 "Checking for insecure root accounts."
 
-  ret=$( echo "SELECT count(*) FROM mysql.user WHERE user='root' and password='';" | $MYSQL --skip-column-names )
+  ret=$( echo "SELECT count(*) FROM mysql.user WHERE user='root' and password='' and plugin='';" | $MYSQL --skip-column-names )
   if [ "$ret" -ne "0" ]; then
-    logger -p daemon.warn -i -t$0 "WARNING: mysql.user contains $ret root accounts without password!"
+    logger -p daemon.warn -i -t$0 "WARNING: mysql.user contains $ret root accounts without password or plugin!"
   fi
 }


### PR DESCRIPTION
As per https://wiki.debian.org/Teams/MySQL root using a socket auth was considered. In the case of socket auth password='' so lets expand the check to include an empy plugin.
