### PR TITLE
Remove debian-sys-maint and replace with root+sock

### DIFF
--- a/debian/additions/mariadb.cnf
+++ b/debian/additions/mariadb.cnf
@@ -15,3 +15,10 @@
 #collation-server      = utf8_general_ci 
 #character_set_server   = utf8 
 #collation_server       = utf8_general_ci 
+
+# Needed so the root database user can authenticate without a password but
+# only when running as the unix root user.
+#
+# Also available for other users if required.
+# See https://mariadb.com/kb/en/unix_socket-authentication-plugin/
+plugin-load-add         = auth_socket.so

--- a/debian/mariadb-server-5.5.README.Debian
+++ b/debian/mariadb-server-5.5.README.Debian
@@ -1,12 +1,13 @@
 * MYSQL WON'T START OR STOP?:
 =============================
-You may never ever delete the special mysql user "debian-sys-maint". This
-user together with the credentials in /etc/mysql/debian.cnf are used by the
-init scripts to stop the server as they would require knowledge of the mysql
-root users password else.
-So in most of the times you can fix the situation by making sure that the
-debian.cnf file contains the right password, e.g. by setting a new one
-(remember to do a "flush privileges" then).
+You may never ever delete the mysql user "root". Although it has no password
+is set, the unix_auth plugin ensure that it can only be run locally as the root
+user. The credentials in /etc/mysql/debian.cnf specify the user are used by the
+init scripts to stop the server and perform logrotation. So in most of the
+time you can fix the situation by making sure that the /etc/mysql/debian.cnf
+file specifies the root user and no password.
+
+This used to be the debian-sys-maint user which is no longer used.
 
 * WHAT TO DO AFTER UPGRADES:
 ============================
@@ -60,23 +61,38 @@ documentation, please go to http://dev.mysql.com/doc.
 
 * PASSWORDS:
 ============
-It is strongly recommended to set a password for the mysql root user (which
-  /usr/bin/mysql -u root -D mysql -e "update user set password=password('new-password') where user='root'"
-  /usr/bin/mysql -u root -e "flush privileges"
-If you already had a password set add "-p" before "-u" to the lines above.
+It is strongly recommended you create an admin users for your database
+adminstration needs.
 
+If your your local unix account is the one you want to have local super user
+access on your database with you can create the following account that will
+only work for the local unix user connecting to the database locally.
 
-If you are tired to type the password in every time or want to automate your
-scripts you can store it in the file $HOME/.my.cnf. It should be chmod 0600
-(-rw------- username username .my.cnf) to ensure that nobody else can read
-it.  Every other configuration parameter can be stored there, too. You will
-find an example below and more information in the MySQL manual in
-/usr/share/doc/mariadb-doc or www.mysql.com.
+  sudo /usr/bin/mysql -e "GRANT ALL ON *.* TO '$USER'@'localhost' IDENTIFIED VIA unix_socket WITH GRANT OPTION"
 
-ATTENTION: It is necessary, that a .my.cnf from root always contains a "user"
+To create a local machine account username=USERNAME with a password:
+
+  sudo /usr/bin/mysql -e "GRANT ALL ON *.* TO 'USERNAME'@'localhost' IDENTIFIED BY 'password' WITH GRANT OPTION"
+
+To create a USERNAME user with password 'password' admin user that can access
+the DB server over the network:
+
+  sudo /usr/bin/mysql -e "GRANT ALL ON *.* TO 'USERNAME'@'%' IDENTIFIED BY 'password' WITH GRANT OPTION"
+
+Scripts should run as a user have have the required grants and be identified via unix_socket.
+
+If you are too tired to type the password in every time and unix_socket auth
+doesn't suit your needs, you can store it in the file $HOME/.my.cnf. It should
+be chmod 0600 (-rw------- username username .my.cnf) to ensure that nobody else
+can read it.  Every other configuration parameter can be stored there, too.
+
+For more information in the MariaDB manual in/usr/share/doc/mariadb-doc or 
+https://mariadb.com/kb/en/configuring-mariadb-with-mycnf/.
+
+ATTENTION: It is necessary, that a ~/.my.cnf from root always contains a "user"
 line wherever there is a "password" line, else, the Debian maintenance
 scripts, that use /etc/mysql/debian.cnf, will use the username
-"debian-sys-maint" but the password that is in root's .my.cnf. Also note,
+"root" but the password that is in root's .my.cnf. Also note,
 that every change you make in the /root/.my.cnf will affect the mysql cron
 script, too.
 

--- a/debian/mariadb-server-5.5.mysql-server.logrotate
+++ b/debian/mariadb-server-5.5.mysql-server.logrotate
@@ -15,7 +15,7 @@
 		# If this fails, check debian.conf!
 		MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 		if [ -z "`$MYADMIN ping 2>/dev/null`" ]; then
-		  # Really no mysqld or rather a missing debian-sys-maint user?
+		  # Really no mysqld or in incorrect authentication in /etc/mysqll/debian.cnf user?
 		  # If this occurs and is not a error please report a bug.
 		  if ps cax | grep -q mysqld; then
  		    exit 1

--- a/debian/mariadb-server-5.5.postinst
+++ b/debian/mariadb-server-5.5.postinst
@@ -21,7 +21,7 @@ invoke() {
   fi
 }
 
-MYSQL_BOOTSTRAP="/usr/sbin/mysqld --bootstrap --user=mysql --skip-grant-tables --loose-innodb=OFF --default-storage-engine=myisam"
+MYSQL_BOOTSTRAP="/usr/sbin/mysqld --bootstrap --user=mysql --skip-grant-tables --loose-innodb=OFF --default-storage-engine=myisam --plugin-load-add=auth_socket"
 
 test_mysql_access() {
        mysql --no-defaults -u root -h localhost </dev/null >/dev/null 2>&1
@@ -40,12 +40,11 @@ set_mysql_rootpw() {
        # this avoids us having to call "test" or "[" on $rootpw
        cat << EOF > $tfile
 USE mysql;
-UPDATE user SET password=PASSWORD("$rootpw") WHERE user='root';
+SET sql_log_bin=0;
+UPDATE user SET password="", plugin="unix_socket" WHERE user='root';
 FLUSH PRIVILEGES;
 EOF
-       if grep -q 'PASSWORD("")' $tfile; then
-               retval=0
-       elif [ "$1" = "online" ]; then
+       if [ "$1" = "online" ]; then
                mysql --no-defaults -u root -h localhost <$tfile >/dev/null
                retval=$?
        else
@@ -166,26 +165,30 @@ EOF
     #   As the binlog cron scripts to need at least the Super_priv, I do first
     #   the old query which always succeeds and then the new which may or may not.
 
-    # recreate the credentials file if not present or without mysql_upgrade stanza
+    # recreate the credentials file if not present or with debian-sys-maint
+    # still there
     dc=$mysql_cfgdir/debian.cnf;
-    if [ -e "$dc" -a -n "`fgrep mysql_upgrade $dc 2>/dev/null`" ]; then
-        pass="`sed -n 's/^[     ]*password *= *// p' $dc | head -n 1`"
-    else
-	pass=`perl -e 'print map{("a".."z","A".."Z",0..9)[int(rand(62))]}(1..16)'`;
+    if [ ! -e "$dc" -o -n "`fgrep debian-sys-maint $dc 2>/dev/null`" ]; then
         if [ ! -d "$mysql_cfgdir" ]; then install -o 0 -g 0 -m 0755 -d $mysql_cfgdir; fi
+        if [ -e "$dc" ]; then
+          oldconf=`mktemp --tmpdir $mysql_cfgdir -t debian_old_config.XXXXXX`
+          cp $dc $oldconf
+        else
+          oldconf=''
+        fi
         umask 066
         cat /dev/null > $dc
         umask 022
         echo "# Automatically generated for Debian scripts. DO NOT TOUCH!" >>$dc
         echo "[client]"                                                    >>$dc
         echo "host     = localhost"                                        >>$dc
-        echo "user     = debian-sys-maint"                                 >>$dc
-        echo "password = $pass"                                            >>$dc
+        echo "user     = root"                                             >>$dc
+        echo "password = "                                                 >>$dc
         echo "socket   = $mysql_rundir/mysqld.sock"                        >>$dc
         echo "[mysql_upgrade]"                                             >>$dc
         echo "host     = localhost"                                        >>$dc
-        echo "user     = debian-sys-maint"                                 >>$dc
-        echo "password = $pass"                                            >>$dc
+        echo "user     = root"                                             >>$dc
+        echo "password = "                                                 >>$dc
         echo "socket   = $mysql_rundir/mysqld.sock"                        >>$dc
         echo "basedir  = /usr"                                             >>$dc
     fi
@@ -196,42 +199,43 @@ EOF
     # update privilege tables
     password_column_fix_query=`/bin/echo -e \
         "USE mysql;\n" \
+        "SET sql_log_bin=0;\n" \
         "ALTER TABLE user CHANGE Password Password char(41) character set latin1 collate latin1_bin DEFAULT '' NOT NULL;"`
-    replace_query=`/bin/echo -e \
-        "USE mysql;\n" \
-        "SET sql_mode='';\n" \
-        "REPLACE INTO user SET " \
-        "  host='localhost', user='debian-sys-maint', password=password('$pass'), " \
-        "  Select_priv='Y', Insert_priv='Y', Update_priv='Y', Delete_priv='Y', " \
-        "  Create_priv='Y', Drop_priv='Y', Reload_priv='Y', Shutdown_priv='Y', " \
-        "  Process_priv='Y',  File_priv='Y', Grant_priv='Y', References_priv='Y', " \
-        "  Index_priv='Y', Alter_priv='Y', Super_priv='Y', Show_db_priv='Y', "\
-        "  Create_tmp_table_priv='Y', Lock_tables_priv='Y', Execute_priv='Y', "\
-        "  Repl_slave_priv='Y', Repl_client_priv='Y', Create_view_priv='Y', "\
-        "  Show_view_priv='Y', Create_routine_priv='Y', Alter_routine_priv='Y', "\
-        "  Create_user_priv='Y', Event_priv='Y', Trigger_priv='Y',"\
-        "  ssl_cipher='', x509_issuer='', x509_subject='';"`;
+
+    replace_query="USE mysql; SET sql_mode='', sql_log_bin=0; DROP USER 'debian-sys-maint'@'localhost';"
+
     # Engines supported by etch should be installed per default. The query sequence is supposed
     # to be aborted if the CREATE TABLE fails due to an already existent table in which case the
     # admin might already have chosen to remove one or more plugins. Newlines are necessary.
     install_plugins=`/bin/echo -e \
         "USE mysql;\n" \
+        "SET sql_log_bin=0;\n" \
         "CREATE TABLE IF NOT EXISTS plugin (name char(64) COLLATE utf8_bin NOT NULL DEFAULT '', " \
         "  dl char(128) COLLATE utf8_bin NOT NULL DEFAULT '', " \
         "  PRIMARY KEY (name)) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='MySQL plugins';" `
 
     # Upgrade password column format before the root password gets set.
     echo "$password_column_fix_query"                        | $MYSQL_BOOTSTRAP 2>&1 | $ERR_LOGGER
+    # install unix_socket plugin but ignore if already there
+    set +e
+    echo "$install_plugins"                                  | $MYSQL_BOOTSTRAP 2>&1 | $ERR_LOGGER
+    set -e
+    # overly complicated here but ensures a plugin unix_socket is installed and is idpotent if already installed
+    echo "SET sql_log_bin=0; USE mysql; DELIMITER //; CREATE PROCEDURE debian_plugin_install(IN plugin_name CHAR(50), IN soname CHAR(50)) BEGIN DECLARE CONTINUE HANDLER FOR NOT FOUND  EXECUTE inst_plug; set @plugin_name=plugin_name; set @soname=soname ;set @install_plugin=CONCAT(\"INSTALL PLUGIN \",@plugin_name,\" SONAME '\", @soname, \"'\");PREPARE inst_plug FROM @install_plugin ; select PLUGIN_NAME INTO @a from  information_schema.plugins where PLUGIN_NAME=@plugin_name AND PLUGIN_STATUS='ACTIVE' AND PLUGIN_TYPE='AUTHENTICATION' AND PLUGIN_LIBRARY LIKE concat(@soname,'%'); DEALLOCATE PREPARE inst_plug; END// CALL debian_plugin_install('unix_socket', 'auth_socket') // DROP PROCEDURE debian_plugin_install//" | $MYSQL_BOOTSTRAP 2>&1 | $ERR_LOGGER
 
     db_get mysql-server/root_password && rootpw="$RET"
     if ! set_mysql_rootpw; then
         password_error="yes"
+        # restore old config file if exists
+        [ -e $oldconf ] && mv $oldconf $dc
+    else
+        [ -e $oldconf ] && rm -f $oldconf
+        # purge debian-sys-maint user
+        set +e
+        echo "$replace_query"                                    | $MYSQL_BOOTSTRAP 2>&1 | $ERR_LOGGER
+        set -e
     fi
 
-    set +e
-    echo "$replace_query"                                    | $MYSQL_BOOTSTRAP 2>&1 | $ERR_LOGGER
-    echo "$install_plugins"                                  | $MYSQL_BOOTSTRAP 2>&1 | $ERR_LOGGER
-    set -e
   ;;
 
   abort-upgrade|abort-remove|abort-configure)


### PR DESCRIPTION
https://wiki.debian.org/Teams/MySQL mentioned using a socket authentication.

This is a straw example on how it could work with mariadb. There are many aspects of debian packaging I don't follow however I hope this can form as a base.

Also uses sql_log_bin=0 so replication slaves don't pick up changes from the master's upgrade.
